### PR TITLE
Building Yad from a github action script

### DIFF
--- a/.github/workflows/build-yad.yml
+++ b/.github/workflows/build-yad.yml
@@ -26,10 +26,14 @@ jobs:
           git checkout v$YAD_VERSION
 
     - name: Retrieve linux deploy
+      working-directory: yad-dialog-code
       run: |
           wget https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage
-          chmod +x ./linuxdeploy-x86_64.AppImage
+          wget -c "https://raw.githubusercontent.com/linuxdeploy/linuxdeploy-plugin-gtk/master/linuxdeploy-plugin-gtk.sh"
+          sed -i '/export GTK_THEME/d' linuxdeploy-plugin-gtk.sh
+          chmod +x ./linuxdeploy-x86_64.AppImage ./linuxdeploy-plugin-gtk.sh
           ./linuxdeploy-x86_64.AppImage --appimage-extract
+          ./linuxdeploy-plugin-gtk.sh --help
 
     - name: Build Yad
       working-directory: yad-dialog-code
@@ -58,15 +62,16 @@ jobs:
     - name: Create Appimage
       working-directory: yad-dialog-code
       run: |
-        ../squashfs-root/AppRun \
+        ./squashfs-root/AppRun \
           --appdir ./AppDir \
           -i ./data/icons/128x128/yad.png \
           --executable ./AppDir/bin/yad \
           -d ./yad.desktop \
+          --plugin gtk \
           --output appimage
 
     - name: Move Appimage
-      run: mv ./yad-dialog-code/*.AppImage Yad-$YAD_VERSION-x86_64.AppImage
+      run: mv ./yad-dialog-code/Yad-x86_64.AppImage Yad-$YAD_VERSION-x86_64.AppImage
 
     - name: Calculate Appimage hash
       run: sha512sum Yad-$YAD_VERSION-x86_64.AppImage > Yad-$YAD_VERSION-x86_64.AppImage.sha512sum

--- a/.github/workflows/build-yad.yml
+++ b/.github/workflows/build-yad.yml
@@ -1,0 +1,85 @@
+name: Build and release yad
+
+on:
+  workflow_dispatch:
+
+env:
+  YAD_VERSION: "13.0"
+
+jobs:
+  build:
+
+    runs-on: ubuntu-22.04
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install required packages
+      run: |
+          sudo apt-get update
+          sudo apt-get install autoconf automake intltool libgtk-3-dev libglib2.0-dev libwebkit2gtk-4.0-dev
+
+    - name: Retrieve Yad source code
+      run: |
+          git clone https://github.com/v1cont/yad/ yad-dialog-code
+          cd yad-dialog-code
+          git checkout v$YAD_VERSION
+
+    - name: Retrieve linux deploy
+      run: |
+          wget https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage
+          chmod +x ./linuxdeploy-x86_64.AppImage
+          ./linuxdeploy-x86_64.AppImage --appimage-extract
+
+    - name: Build Yad
+      working-directory: yad-dialog-code
+      run: |
+          autoreconf -ivf
+          intltoolize
+          ./configure prefix=$(pwd)/AppDir --enable-standalone
+          make
+          make install
+
+    - name: Prepare .desktop file
+      working-directory: yad-dialog-code
+      run: |
+          cat << EOF > ./yad.desktop 
+          [Desktop Entry]
+          Encoding=UTF-8
+          Name=Yad
+          Categories=GTK;Development;
+          Exec=yad
+          Icon=yad
+          Terminal=true
+          Type=Application
+          StartupNotify=true
+          EOF
+
+    - name: Create Appimage
+      working-directory: yad-dialog-code
+      run: |
+        ../squashfs-root/AppRun \
+          --appdir ./AppDir \
+          -i ./data/icons/128x128/yad.png \
+          --executable ./AppDir/bin/yad \
+          -d ./yad.desktop \
+          --output appimage
+
+    - name: Move Appimage
+      run: mv ./yad-dialog-code/*.AppImage Yad-$YAD_VERSION-x86_64.AppImage
+
+    - name: Calculate Appimage hash
+      run: sha512sum Yad-$YAD_VERSION-x86_64.AppImage > Yad-$YAD_VERSION-x86_64.AppImage.sha512sum
+
+    - name: Version workaround # See https://github.com/softprops/action-gh-release/issues/360#issuecomment-1599767780
+      id: yad_version
+      run: echo "version=$YAD_VERSION" >> "$GITHUB_OUTPUT"
+
+    - name: Release
+      uses: softprops/action-gh-release@v2
+      with:
+        files: |
+          Yad-${{ steps.yad_version.outputs.version }}-x86_64.AppImage
+          Yad-${{ steps.yad_version.outputs.version }}-x86_64.AppImage.sha512sum
+        body: "[`yad`](https://github.com/v1cont/yad) ${{ steps.yad_version.outputs.version }} appimage built on ubuntu with github actions"
+        tag_name: Yad-${{ steps.yad_version.outputs.version }}

--- a/.github/workflows/build-yad.yml
+++ b/.github/workflows/build-yad.yml
@@ -31,6 +31,7 @@ jobs:
           wget https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage
           wget -c "https://raw.githubusercontent.com/linuxdeploy/linuxdeploy-plugin-gtk/master/linuxdeploy-plugin-gtk.sh"
           sed -i '/export GTK_THEME/d' linuxdeploy-plugin-gtk.sh
+          sed -i '/export GDK_BACKEND/d' linuxdeploy-plugin-gtk.sh
           chmod +x ./linuxdeploy-x86_64.AppImage ./linuxdeploy-plugin-gtk.sh
           ./linuxdeploy-x86_64.AppImage --appimage-extract
           ./linuxdeploy-plugin-gtk.sh --help


### PR DESCRIPTION
This draft allows building the latest version of Yad (13.0) from a GitHub action using a simple workflow dispatch and making a release for it. Marking it as a draft since it needs some testing.

I will make a force push to have it in a single commit, you can try the created yad appimage here https://github.com/AtomHare/steamtinkerlaunch-tweaks/releases

Related to https://github.com/sonic2kk/steamtinkerlaunch/issues/859