### PR TITLE
fix: release tag to match STL behaviour

### DIFF
--- a/.github/workflows/build-yad.yml
+++ b/.github/workflows/build-yad.yml
@@ -88,4 +88,4 @@ jobs:
           Yad-${{ steps.yad_version.outputs.version }}-x86_64.AppImage
           Yad-${{ steps.yad_version.outputs.version }}-x86_64.AppImage.sha512sum
         body: "[`yad`](https://github.com/v1cont/yad) ${{ steps.yad_version.outputs.version }} appimage built on ubuntu with github actions"
-        tag_name: Yad-${{ steps.yad_version.outputs.version }}
+        tag_name: Yad-${{ steps.yad_version.outputs.version }}-x86_64.AppImage


### PR DESCRIPTION
Yad appimage was recently updated, but the tag expected from STL differs from the current tag `Yad-$VERSION` in this repository, the tag is now back to `Yad-$VERSION-x86_64.AppImage`.

Fix download issue, see https://github.com/sonic2kk/steamtinkerlaunch/pull/1077.